### PR TITLE
style : changed button color : grey (#344) for visibility

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -230,7 +230,7 @@ html:-moz-full-screen-ancestor {
 .reveal .controls .navigate-left {
   top: 42px;
   border-right-width: 22px;
-  border-right-color: #000; }
+  border-right-color: #344; }
 
 .reveal .controls .navigate-left.fragmented {
   opacity: 0.3; }
@@ -239,7 +239,7 @@ html:-moz-full-screen-ancestor {
   left: 74px;
   top: 42px;
   border-left-width: 22px;
-  border-left-color: #000; }
+  border-left-color: #344; }
 
 .reveal .controls .navigate-right.fragmented {
   opacity: 0.3; }
@@ -247,7 +247,7 @@ html:-moz-full-screen-ancestor {
 .reveal .controls .navigate-up {
   left: 42px;
   border-bottom-width: 22px;
-  border-bottom-color: #000; }
+  border-bottom-color: #344; }
 
 .reveal .controls .navigate-up.fragmented {
   opacity: 0.3; }
@@ -256,7 +256,7 @@ html:-moz-full-screen-ancestor {
   left: 42px;
   top: 74px;
   border-top-width: 22px;
-  border-top-color: #000; }
+  border-top-color: #344; }
 
 .reveal .controls .navigate-down.fragmented {
   opacity: 0.3; }


### PR DESCRIPTION
Hi Trey,
I was going through your slides and noticed that the 3rd slide - "_Some programmers just want to mix tabs and spaces_" was having background-color : **black (#000)** and the navigation buttons were not visible on the black background. Changed the color of the buttons to **#344** for better visibility on slides, now it is visible on both slides with white background and the one with black background. PFA the screenshot of the slide before and after changes and let me know if any change is required.

![image](https://user-images.githubusercontent.com/26771338/100774785-7a4af100-3428-11eb-97be-fb79e801067a.png)
![image](https://user-images.githubusercontent.com/26771338/100774889-98b0ec80-3428-11eb-8ab3-a796291983ae.png)
